### PR TITLE
Updated default Laravel App Name

### DIFF
--- a/src/DDTrace/Integrations/LaravelProvider.php
+++ b/src/DDTrace/Integrations/LaravelProvider.php
@@ -136,7 +136,7 @@ class LaravelProvider extends ServiceProvider
         } elseif (is_callable('config')) {
             return config('app.name');
         } else {
-            return 'symfony';
+            return 'laravel';
         }
     }
 }


### PR DESCRIPTION
Updated default Laravel App Name from `symfony` to `laravel` in the service provider.